### PR TITLE
Added source URL to tokens info types and fix build

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,7 +1,7 @@
 [
   {
     "path": "packages/anchor-contrib/dist/index.js",
-    "limit": "1 KB",
+    "limit": "3 KB",
     "ignore": ["@project-serum/anchor", "@solana/web3.js"]
   },
   {

--- a/packages/token-utils/src/tokenList.ts
+++ b/packages/token-utils/src/tokenList.ts
@@ -16,6 +16,11 @@ export type TokenExtensions = tokenRegistry.TokenExtensions & {
    * E.g. `wormhole-v1`, `wormhole-v2`, `allbridge`, `sollet`, `saber`.
    */
   readonly source?: string;
+
+  /*
+   ** Link to the source's website where you can acquire this token
+   */
+  readonly sourceUrl?: string;
   /**
    * The currency code of what this token represents, e.g. BTC, ETH, USD.
    */

--- a/packages/use-solana/src/utils/useWalletInternal.ts
+++ b/packages/use-solana/src/utils/useWalletInternal.ts
@@ -170,7 +170,7 @@ export const useWalletInternal = ({
   );
 
   const disconnect = useCallback(async () => {
-    wallet?.disconnect();
+    await wallet?.disconnect();
     await setWalletConfigStr(null);
   }, [setWalletConfigStr, wallet]);
 


### PR DESCRIPTION
Adding source_url to tokens info types so that users can find where to acquire the tokens on the saber interface