### PR TITLE
Allow ConnectionConfig options to be passed to use-solana

### DIFF
--- a/packages/solana-contrib/src/constants.ts
+++ b/packages/solana-contrib/src/constants.ts
@@ -1,4 +1,4 @@
-import type { Cluster } from "@solana/web3.js";
+import type { Cluster, ConnectionConfig } from "@solana/web3.js";
 
 /**
  * A network: a Solana cluster or localnet.
@@ -17,17 +17,19 @@ export const formatNetwork = (network: Network): string => {
   return network;
 };
 
-export type NetworkConfig = Readonly<{
-  name: string;
-  /**
-   * HTTP endpoint to connect to for this network.
-   */
-  endpoint: string;
-  /**
-   * Websocket endpoint to connect to for this network.
-   */
-  endpointWs?: string;
-}>;
+export type NetworkConfig = Readonly<
+  Omit<ConnectionConfig, "wsEndpoint"> & {
+    name: string;
+    /**
+     * HTTP endpoint to connect to for this network.
+     */
+    endpoint: string;
+    /**
+     * Websocket endpoint to connect to for this network.
+     */
+    endpointWs?: string;
+  }
+>;
 
 /**
  * Default configuration for all networks.

--- a/packages/use-solana/src/utils/useConnectionInternal.ts
+++ b/packages/use-solana/src/utils/useConnectionInternal.ts
@@ -63,25 +63,30 @@ export const useConnectionInternal = ({
   );
   const configMap = makeNetworkConfigMap(networkConfigs);
   const config = configMap[network];
-  const [{ endpoint, endpointWs }, setEndpoints] = usePersistedKVStore<
-    Omit<NetworkConfig, "name">
-  >(`use-solana/rpc-endpoint/${network}`, config, storageAdapter);
+  const [{ endpoint, endpointWs, ...connectionConfigArgs }, setEndpoints] =
+    usePersistedKVStore<Omit<NetworkConfig, "name">>(
+      `use-solana/rpc-endpoint/${network}`,
+      config,
+      storageAdapter
+    );
 
   const connection = useMemo(
     () =>
       new Connection(endpoint, {
-        commitment,
+        ...connectionConfigArgs,
+        commitment: connectionConfigArgs.commitment ?? commitment,
         wsEndpoint: endpointWs,
       }),
-    [commitment, endpoint, endpointWs]
+    [commitment, connectionConfigArgs, endpoint, endpointWs]
   );
   const sendConnection = useMemo(
     () =>
       new Connection(endpoint, {
-        commitment,
+        ...connectionConfigArgs,
+        commitment: connectionConfigArgs.commitment ?? commitment,
         wsEndpoint: endpointWs,
       }),
-    [commitment, endpoint, endpointWs]
+    [commitment, connectionConfigArgs, endpoint, endpointWs]
   );
 
   return {


### PR DESCRIPTION
- Compose `web3.js` `ConnectionConfig` with `NetworkConfig`
- Pass `connectionConfigArgs` to connection variables
  * Maintain backwards compatibility with old argument setup