### PR TITLE
Add configurable wallet providers in use-solana

### DIFF
--- a/packages/use-solana/src/error.ts
+++ b/packages/use-solana/src/error.ts
@@ -1,4 +1,4 @@
-import type { WalletProviderInfo, WalletType } from ".";
+import type { WalletProviderInfo, WalletTypeEnum } from ".";
 
 export enum ErrorLevel {
   WARN = "warn",
@@ -71,17 +71,19 @@ export class WalletDisconnectError extends UseSolanaDerivedError {
 /**
  * Thrown when a wallet activation errors.
  */
-export class WalletActivateError extends UseSolanaDerivedError {
+export class WalletActivateError<
+  WalletType extends WalletTypeEnum<WalletType>
+> extends UseSolanaDerivedError {
   level = ErrorLevel.ERROR;
 
   constructor(
     originalError: unknown,
-    readonly walletType: WalletType,
+    readonly walletType: WalletType[keyof WalletType],
     readonly walletArgs?: Record<string, unknown>
   ) {
     super(
       "WalletActivateError",
-      `Error activating wallet ${walletType}`,
+      `Error activating wallet ${walletType as unknown as string}`,
       originalError
     );
   }

--- a/packages/use-solana/src/hooks.ts
+++ b/packages/use-solana/src/hooks.ts
@@ -1,5 +1,6 @@
 import type { Connection } from "@solana/web3.js";
 
+import type { DefaultWalletType, UnknownWalletType, WalletTypeEnum } from ".";
 import type { ConnectedWallet } from "./adapters/types";
 import type { UseSolana } from "./context";
 import { useSolana } from "./context";
@@ -8,8 +9,10 @@ import type { ConnectionContext } from "./utils/useConnectionInternal";
 /**
  * Gets the current Solana wallet.
  */
-export function useWallet(): UseSolana {
-  const context = useSolana();
+export function useWallet<
+  WalletType extends WalletTypeEnum<WalletType> = typeof DefaultWalletType
+>(): UseSolana<WalletType> {
+  const context = useSolana<WalletType>();
   if (!context) {
     throw new Error("wallet not loaded");
   }
@@ -20,7 +23,7 @@ export function useWallet(): UseSolana {
  * Gets the current Solana wallet, returning null if it is not connected.
  */
 export const useConnectedWallet = (): ConnectedWallet | null => {
-  const { wallet, connected } = useWallet();
+  const { wallet, connected } = useWallet<UnknownWalletType>();
   if (!wallet?.connected || !connected || !wallet.publicKey) {
     return null;
   }
@@ -32,7 +35,7 @@ export const useConnectedWallet = (): ConnectedWallet | null => {
  * @returns
  */
 export function useConnectionContext(): ConnectionContext {
-  const context = useSolana();
+  const context = useSolana<UnknownWalletType>();
   if (!context) {
     throw new Error("Not in context");
   }

--- a/packages/use-solana/src/providers.tsx
+++ b/packages/use-solana/src/providers.tsx
@@ -26,7 +26,7 @@ import {
   SOLLET,
 } from "./icons";
 
-export enum WalletType {
+export enum DefaultWalletType {
   Coin98 = "Coin98",
   Ledger = "Ledger",
   MathWallet = "MathWallet",
@@ -39,9 +39,17 @@ export enum WalletType {
   Solong = "Solong",
   SecretKey = "SecretKey",
 }
+export type WalletTypeEnum<T> = { [name: string]: T[keyof T] | string };
+export type UnknownWalletType = WalletTypeEnum<Record<string, unknown>>;
 
-export const WALLET_PROVIDERS: { [W in WalletType]: WalletProviderInfo } = {
-  [WalletType.Sollet]: {
+export type WalletProviderMap<WalletType extends WalletTypeEnum<WalletType>> = {
+  [W in keyof WalletType]: WalletProviderInfo;
+};
+
+export const DEFAULT_WALLET_PROVIDERS: WalletProviderMap<
+  typeof DefaultWalletType
+> = {
+  [DefaultWalletType.Sollet]: {
     name: "Sollet",
     url: "https://www.sollet.io",
     icon: SOLLET,
@@ -54,7 +62,7 @@ export const WALLET_PROVIDERS: { [W in WalletType]: WalletProviderInfo } = {
       ),
     isMobile: true,
   },
-  [WalletType.SolletExtension]: {
+  [DefaultWalletType.SolletExtension]: {
     name: "Sollet (Extension)",
     url: "https://chrome.google.com/webstore/detail/sollet/fhmfendgdocmcbmfikdcogofphimnkno",
     icon: SOLLET,
@@ -67,13 +75,13 @@ export const WALLET_PROVIDERS: { [W in WalletType]: WalletProviderInfo } = {
 
     isInstalled: () => window.sollet !== undefined,
   },
-  [WalletType.Ledger]: {
+  [DefaultWalletType.Ledger]: {
     name: "Ledger",
     url: "https://www.ledger.com",
     icon: LEDGER,
     makeAdapter: () => new LedgerWalletAdapter(),
   },
-  [WalletType.Solong]: {
+  [DefaultWalletType.Solong]: {
     name: "Solong",
     url: "https://solongwallet.com/",
     icon: "https://raw.githubusercontent.com/solana-labs/oyster/main/assets/wallets/solong.png",
@@ -81,7 +89,7 @@ export const WALLET_PROVIDERS: { [W in WalletType]: WalletProviderInfo } = {
 
     isInstalled: () => window.solong !== undefined,
   },
-  [WalletType.Phantom]: {
+  [DefaultWalletType.Phantom]: {
     name: "Phantom",
     url: "https://www.phantom.app",
     icon: PHANTOM,
@@ -89,7 +97,7 @@ export const WALLET_PROVIDERS: { [W in WalletType]: WalletProviderInfo } = {
 
     isInstalled: () => window.solana?.isPhantom === true,
   },
-  [WalletType.MathWallet]: {
+  [DefaultWalletType.MathWallet]: {
     name: "MathWallet",
     url: "https://www.mathwallet.org",
     icon: MATHWALLET,
@@ -97,7 +105,7 @@ export const WALLET_PROVIDERS: { [W in WalletType]: WalletProviderInfo } = {
     isInstalled: () => window.solana?.isMathWallet === true,
     isMobile: true,
   },
-  [WalletType.Coin98]: {
+  [DefaultWalletType.Coin98]: {
     name: "Coin98",
     url: "https://wallet.coin98.com/",
     icon: COIN98,
@@ -105,13 +113,13 @@ export const WALLET_PROVIDERS: { [W in WalletType]: WalletProviderInfo } = {
     isInstalled: () => window.coin98 !== undefined,
     isMobile: true,
   },
-  [WalletType.SecretKey]: {
+  [DefaultWalletType.SecretKey]: {
     name: "Secret Key",
     url: "https://solana.com/",
     icon: FILE,
     makeAdapter: () => new SecretKeyAdapter(),
   },
-  [WalletType.Solflare]: {
+  [DefaultWalletType.Solflare]: {
     name: "Solflare (Web)",
     url: "https://solflare.com/provider",
     icon: SOLFLARE,
@@ -123,7 +131,7 @@ export const WALLET_PROVIDERS: { [W in WalletType]: WalletProviderInfo } = {
         })
       ),
   },
-  [WalletType.SolflareExtension]: {
+  [DefaultWalletType.SolflareExtension]: {
     name: "Solflare (Extension)",
     url: "https://solflare.com/",
     icon: SOLFLARE,
@@ -131,7 +139,7 @@ export const WALLET_PROVIDERS: { [W in WalletType]: WalletProviderInfo } = {
 
     isInstalled: () => window.solflare?.isSolflare === true,
   },
-  [WalletType.Slope]: {
+  [DefaultWalletType.Slope]: {
     name: "Slope",
     url: "https://www.slope.finance/",
     icon: SLOPE,

--- a/packages/use-solana/src/utils/useWalletInternal.ts
+++ b/packages/use-solana/src/utils/useWalletInternal.ts
@@ -11,23 +11,29 @@ import {
   WalletAutomaticConnectionError,
   WalletDisconnectError,
 } from "../error";
-import type { WalletProviderInfo, WalletType } from "../providers";
-import { WALLET_PROVIDERS } from "../providers";
+import type {
+  WalletProviderInfo,
+  WalletProviderMap,
+  WalletTypeEnum,
+} from "../providers";
 import type { StorageAdapter } from "../storage";
 import { usePersistedKVStore } from "./usePersistedKVStore";
 
 /**
  * Wallet-related information.
  */
-export interface UseWallet<T extends boolean = boolean> {
+export interface UseWallet<
+  WalletType extends WalletTypeEnum<WalletType>,
+  Connected extends boolean = boolean
+> {
   /**
    * Wallet.
    */
-  wallet?: WalletAdapter<T>;
+  wallet?: WalletAdapter<Connected>;
   /**
    * Wallet public key.
    */
-  publicKey: T extends true ? PublicKey : undefined;
+  publicKey: Connected extends true ? PublicKey : undefined;
   /**
    * Information about the wallet used.
    */
@@ -35,12 +41,12 @@ export interface UseWallet<T extends boolean = boolean> {
   /**
    * Whether or not the wallet is connected.
    */
-  connected: T;
+  connected: Connected;
   /**
    * Activates a new wallet.
    */
   activate: (
-    walletType: WalletType,
+    walletType: WalletType[keyof WalletType],
     walletArgs?: Record<string, unknown>
   ) => Promise<void>;
   /**
@@ -49,7 +55,7 @@ export interface UseWallet<T extends boolean = boolean> {
   disconnect: () => void;
 }
 
-export interface UseWalletArgs {
+export interface UseWalletArgs<WalletType extends WalletTypeEnum<WalletType>> {
   onConnect: (
     wallet: WalletAdapter<true>,
     provider: WalletProviderInfo
@@ -62,29 +68,33 @@ export interface UseWalletArgs {
   network: Network;
   endpoint: string;
   storageAdapter: StorageAdapter;
+  walletProviders: WalletProviderMap<WalletType>;
 }
 
-interface WalletConfig {
-  walletType: WalletType;
+interface WalletConfig<WalletType extends WalletTypeEnum<WalletType>> {
+  walletType: keyof WalletType;
   walletArgs: Record<string, unknown> | null;
 }
 
-export const useWalletInternal = ({
+export const useWalletInternal = <
+  WalletType extends WalletTypeEnum<WalletType>
+>({
   onConnect,
   onDisconnect,
   network,
   endpoint,
   onError,
   storageAdapter,
-}: UseWalletArgs): UseWallet<boolean> => {
+  walletProviders,
+}: UseWalletArgs<WalletType>): UseWallet<WalletType, boolean> => {
   const [walletConfigStr, setWalletConfigStr] = usePersistedKVStore<
     string | null
   >("use-solana/wallet-config", null, storageAdapter);
 
-  const walletConfig: WalletConfig | null = useMemo(() => {
+  const walletConfig: WalletConfig<WalletType> | null = useMemo(() => {
     try {
       return walletConfigStr
-        ? (JSON.parse(walletConfigStr) as WalletConfig)
+        ? (JSON.parse(walletConfigStr) as WalletConfig<WalletType>)
         : null;
     } catch (e) {
       console.warn("Error parsing wallet config", e);
@@ -102,13 +112,13 @@ export const useWalletInternal = ({
     | readonly [WalletProviderInfo, WalletAdapter]
     | readonly [undefined, undefined] = useMemo(() => {
     if (walletType) {
-      const provider = WALLET_PROVIDERS[walletType];
+      const provider = walletProviders[walletType];
       console.debug("New wallet", provider.url, network);
       const adapter = provider.makeAdapter(provider.url, endpoint);
       return [provider, new WrappedWalletAdapter(adapter)];
     }
     return [undefined, undefined];
-  }, [walletType, network, endpoint]);
+  }, [walletProviders, walletType, network, endpoint]);
 
   useEffect(() => {
     let disabled = false;
@@ -164,7 +174,7 @@ export const useWalletInternal = ({
 
   const activate = useCallback(
     async (
-      nextWalletType: WalletType,
+      nextWalletType: WalletType[keyof WalletType],
       nextWalletArgs?: Record<string, unknown>
     ): Promise<void> => {
       const nextWalletConfigStr = stringify({
@@ -176,7 +186,13 @@ export const useWalletInternal = ({
         try {
           await wallet?.connect(nextWalletArgs);
         } catch (e) {
-          onError(new WalletActivateError(e, nextWalletType, nextWalletArgs));
+          onError(
+            new WalletActivateError<WalletType>(
+              e,
+              nextWalletType,
+              nextWalletArgs
+            )
+          );
         }
       }
       await setWalletConfigStr(nextWalletConfigStr);


### PR DESCRIPTION
- Update internal wallet provider naming
  * Prefix with default, export types
- Update `useWalletInternal` to support receving `walletProviders` as a map
  * Add generics to pass `WalletType` enum info into hook
  * Update `UseWallet` interface generic arguments
  * Update error type to accept custom type
- Update `useSolanaInternal` to receive `walletProviders`
- Update Solana container types to support unknown initialization
- Update `SolanaProvider` generic arguments
- Update `useWallet` hook to accept type generic
  * Consumer provides custom type if using different wallet providers
  * Other hooks do not require generic arguments