### PR TITLE
use-solana: Fix disconnect type on UseWallet

### DIFF
--- a/packages/use-solana/src/utils/useWalletInternal.ts
+++ b/packages/use-solana/src/utils/useWalletInternal.ts
@@ -46,7 +46,7 @@ export interface UseWallet<T extends boolean = boolean> {
   /**
    * Disconnects the wallet and prevents auto-reconnect.
    */
-  disconnect: () => void;
+  disconnect: () => Promise<void>;
 }
 
 export interface UseWalletArgs {


### PR DESCRIPTION
The `disconnect` method returns a `Promise<void>` in the `useWalletInternal` hook, but the return type is described as a `void`. This PR updates the type so consumers can await a disconnect.