### PR TITLE
use-solana: Set mobile compatibility for Solflare

### DIFF
--- a/packages/use-solana/src/providers.tsx
+++ b/packages/use-solana/src/providers.tsx
@@ -135,6 +135,7 @@ export const DEFAULT_WALLET_PROVIDERS: WalletProviderMap<
     makeAdapter: () => new SolanaWalletAdapter(new SolflareWalletAdapter()),
 
     isInstalled: () => window.solflare?.isSolflare === true,
+    isMobile: true,
   },
   [DefaultWalletType.Slope]: {
     name: "Slope",


### PR DESCRIPTION
Set `isMobile` to true for Solflare extension for compatibility with the Solflare mobile app