### PR TITLE
Improve comments on recent debugging utils

### DIFF
--- a/packages/chai-solana/src/debugAccountOwners.ts
+++ b/packages/chai-solana/src/debugAccountOwners.ts
@@ -1,0 +1,43 @@
+import { Provider as AnchorProvider } from "@project-serum/anchor";
+import { printAccountOwners } from "@saberhq/solana-contrib";
+
+/**
+ * A wrapper around `printAccountOwners` that loads the connection from env().
+ * This is useful for people who are too lazy to pass in a connection.
+ *
+ * --------
+ *
+ * A useful tool for debugging account structs. It gives a quick glance at
+ * addresses and owners. It also converts bignums into JS numbers.
+ *
+ * Types converted:
+ * - **big numbers**: converted to native numbers
+ * - **addresses**: format in base58, and prints the owner in parentheses if the account exists
+ * - **plain objects**: recursively converts
+ *
+ * HINT: This function is mainly useful for the browser. If you are writing
+ * Rust integration tests, use debugAccountOwners from chai-solana instead, so
+ * that you don't have to pass in connection.
+ *
+ * Usage:
+ * ```
+ * await debugAccountOwners(depositAccounts); // using await is recommended, due to race conditions
+ * void debugAccountOwners(depositAccounts); // don't do this in tests, there may be race conditions
+ * ```
+ *
+ * Example output:
+ * ```
+ * tests/awesomeTest.spec.ts:583:29 {
+ *   payer: 'CEGhKVeyXUrihUnNU9EchSuu6pMHEsB8MiKgvhJqYgd1 (11111111111111111111111111111111)',
+ *   foo: '61tMNVhG66QZQ4UEAoHytqaUN4G1xpk1zsS5YU7Y2Qui (135QzSyjKTKaZ7ebhLpvNA2KUahEjykMjbqz3JV1V4k9)',
+ *   bar: '9oPMxXVSm5msAecxi4zJpKDwbHS9c6Yos1ru739rVExc (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)',
+ *   tokenProgram: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (BPFLoader2111111111111111111111111111111111)'
+ * }
+ * ```
+ *
+ * WARNING: This may break silently if web3 changes its api. This is only
+ * intended for debugging purposes only.
+ */
+export async function debugAccountOwners(plainObj: object): Promise<void> {
+  return printAccountOwners(AnchorProvider.env().connection, plainObj);
+}

--- a/packages/chai-solana/src/index.ts
+++ b/packages/chai-solana/src/index.ts
@@ -7,8 +7,8 @@ import { PublicKey } from "@solana/web3.js";
 import chaiAsPromised from "chai-as-promised";
 import chaiBN from "chai-bn";
 
+export * from "./debugAccountOwners";
 export * from "./expectTXTable";
-export * from "./printAccountOwners";
 export * from "./utils";
 
 export const chaiSolana: Chai.ChaiPlugin = (chai) => {

--- a/packages/solana-contrib/src/utils/index.ts
+++ b/packages/solana-contrib/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./instructions";
+export * from "./printAccountOwners";
 export * from "./printTXTable";
 export * from "./publicKey";
 export * from "./simulateTransactionWithCommitment";

--- a/packages/solana-contrib/src/utils/printTXTable.ts
+++ b/packages/solana-contrib/src/utils/printTXTable.ts
@@ -85,16 +85,34 @@ export const printTXTable = (
   console.table(instructionTable);
 };
 
+/**
+ * Builds a transaction and estimates the size in bytes. This number is primrily
+ * to be used for checking to see if a transaction is too big and instructions
+ * need to be split. It may not be 100% accurate.
+ *
+ * This is used in expectTXTable and is useful for increasing efficiency in
+ * dapps that build large transactions.
+ *
+ * The max transaction size of a v1 Transaction in Solana is 1232 bytes.
+ * For info about Transaction v2: https://docs.solana.com/proposals/transactions-v2
+ *
+ * Returns 8888 if the transaction was too big.
+ * Returns 9999 if the transaction was unable to be built.
+ */
 export const estimateTransactionSize = (
   txEnvelope: TransactionEnvelope
 ): number => {
+  // Hide the console.error because txEnvelope.build() emits noisy errors as a
+  // side effect. There are use cases of estimateTransactionSize where we
+  // frequently build transactions that are likely too big.
   const oldConsoleError = console.error;
   console.error = () => {
     return;
   };
   try {
     const builtTx = txEnvelope.build();
-    builtTx.recentBlockhash = "MaryHadALittLeLambZNdhAUTrsLE1ydg6rmtvFEpKT"; // dummy blockhash
+    // dummy blockhash that is required for building the transaction
+    builtTx.recentBlockhash = "MaryHadALittLeLambZNdhAUTrsLE1ydg6rmtvFEpKT";
 
     const fs = getFakeSigner();
     builtTx.feePayer = fs.publicKey;


### PR DESCRIPTION
- Added a bunch of comments.
- `printAccountOwners` now works in the browser
- `debugAccountOwners` is for Node.js and doesn't require passing in a connection
- I've tested all functions in both the browser and in integration tests
- Contains breaking changes to the previous version, but should be fine since that was only 10 hours ago

Here is a fancy screenshot of expectTXTable and printAccountOwners
![image](https://user-images.githubusercontent.com/88907597/147701561-a4cb8fec-dbd9-4b99-95f7-d9df0f55e088.png)
