### PR TITLE
Fix 2 small bugs with debugAccountOwners and expectTXTable

### DIFF
--- a/packages/chai-solana/src/expectTXTable.ts
+++ b/packages/chai-solana/src/expectTXTable.ts
@@ -27,7 +27,7 @@ import { expectTX } from "./utils";
  */
 export const expectTXTable = (
   tx: TransactionEnvelope,
-  msg: string,
+  msg?: string,
   verbosity?: "printLogs"
 ): Chai.PromisedAssertion => {
   if (tx === null) {
@@ -63,7 +63,7 @@ export const expectTXTable = (
         printTXTable(
           tx,
           simulation.value.logs,
-          `${msg} ${relativePath ? ` (${relativePath})` : ""}`
+          `${msg ? msg + " " : ""}${relativePath ? `(${relativePath})` : ""}`
         );
       }
 
@@ -102,5 +102,5 @@ export const expectTXTable = (
       }
     });
 
-  return expectTX(tx, msg + (relativePath ? ` (${relativePath})` : ""));
+  return expectTX(tx, (msg || "") + (relativePath ? ` (${relativePath})` : ""));
 };

--- a/packages/solana-contrib/src/utils/printAccountOwners.ts
+++ b/packages/solana-contrib/src/utils/printAccountOwners.ts
@@ -46,9 +46,19 @@ export async function printAccountOwners(
       let relativePath: string | undefined;
       const callStack = new Error().stack?.split("\n");
       if (callStack) {
-        const expectIndex = callStack.findIndex((l) =>
+        let expectIndex = callStack.findIndex((l) =>
           l.includes(`at ${printAccountOwners.name}`)
         );
+
+        // debugAccountOwners in chai-solana wraps printAccountOwners
+        // We need to get the caller of debugAccountOwners instead
+        const debugAccountOwnersIndex = callStack.findIndex((l) =>
+          l.includes(`at debugAccountOwners`)
+        );
+        if (debugAccountOwnersIndex > expectIndex) {
+          expectIndex = debugAccountOwnersIndex;
+        }
+
         // Only log the line number in Node.js
         if (
           expectIndex > 0 &&


### PR DESCRIPTION
Fixes 2 bugs:
1. debugAccountOwners would end up printing the line number of debugAccountOwners because printAccountOwners prints the its caller line number
2. expectTXTable had double spaces