### PR TITLE
feat: Implement waitV2 confirming transaction with `onSignature` subscription

### DIFF
--- a/packages/chai-solana/src/utils.ts
+++ b/packages/chai-solana/src/utils.ts
@@ -28,9 +28,9 @@ export const expectTX = (
       tx
         .then((tx) => {
           if (tx instanceof PendingTransaction) {
-            return tx.wait();
+            return tx.waitV2();
           } else if (tx) {
-            return tx.confirm();
+            return tx.confirm({ useWaitV2: true });
           } else {
             throw new Error("tx is null");
           }
@@ -40,12 +40,12 @@ export const expectTX = (
     ).eventually;
   }
   if (tx instanceof PendingTransaction) {
-    return expect(tx.wait().then(handleReceipt), msg).eventually;
+    return expect(tx.waitV2().then(handleReceipt), msg).eventually;
   } else {
     return expect(
       tx
         ?.send()
-        .then((res) => res.wait())
+        .then((res) => res.waitV2())
         .then(handleReceipt),
       msg
     ).eventually;

--- a/packages/solana-contrib/src/interfaces.ts
+++ b/packages/solana-contrib/src/interfaces.ts
@@ -153,7 +153,9 @@ export interface Provider extends ReadonlyProvider {
   /**
    * Transaction confirmation options to use by default.
    */
-  opts: ConfirmOptions;
+  opts: ConfirmOptions & {
+    useWaitV2?: boolean;
+  };
 
   /**
    * The wallet used to pay for and sign all transactions.
@@ -171,7 +173,9 @@ export interface Provider extends ReadonlyProvider {
   send: (
     tx: Transaction,
     signers?: (Signer | undefined)[],
-    opts?: ConfirmOptions
+    opts?: ConfirmOptions & {
+      useWaitV2?: boolean;
+    }
   ) => Promise<PendingTransaction>;
 
   /**
@@ -179,7 +183,9 @@ export interface Provider extends ReadonlyProvider {
    */
   sendAll: (
     reqs: readonly SendTxRequest[],
-    opts?: ConfirmOptions
+    opts?: ConfirmOptions & {
+      useWaitV2?: boolean;
+    }
   ) => Promise<PendingTransaction[]>;
 
   /**

--- a/packages/solana-contrib/src/transaction/PendingTransaction.ts
+++ b/packages/solana-contrib/src/transaction/PendingTransaction.ts
@@ -96,14 +96,7 @@ export class PendingTransaction {
           retry(new Error(`Error confirming transaction: ${error.message}`));
           return;
         }
-        const resp = await this.connection.getTransaction(this.signature, {
-          commitment,
-        });
-        if (!resp) {
-          new Error(`Failed to fetch transaction for ${this.signature}`);
-          return;
-        }
-        return new TransactionReceipt(this.signature, resp);
+        return new TransactionReceipt(this.signature);
       },
       {
         retries: 3,

--- a/packages/solana-contrib/src/transaction/TransactionEnvelope.ts
+++ b/packages/solana-contrib/src/transaction/TransactionEnvelope.ts
@@ -214,7 +214,12 @@ export class TransactionEnvelope {
    * Sends the transaction and waits for confirmation.
    * @param opts
    */
-  async confirm(opts?: ConfirmOptions): Promise<TransactionReceipt> {
+  async confirm(
+    opts?: ConfirmOptions & { useWaitV2?: boolean }
+  ): Promise<TransactionReceipt> {
+    if (opts?.useWaitV2) {
+      return (await this.send(opts)).waitV2();
+    }
     return (await this.send(opts)).wait();
   }
 
@@ -328,7 +333,7 @@ export class TransactionEnvelope {
    */
   static async sendAll(
     txs: TransactionEnvelope[],
-    opts?: ConfirmOptions
+    opts?: ConfirmOptions & { useWaitV2?: boolean }
   ): Promise<PendingTransaction[]> {
     const firstTX = txs[0];
     if (!firstTX) {

--- a/packages/solana-contrib/src/transaction/TransactionReceipt.ts
+++ b/packages/solana-contrib/src/transaction/TransactionReceipt.ts
@@ -18,13 +18,14 @@ export class TransactionReceipt {
     /**
      * Raw response from web3.js
      */
-    readonly response: TransactionResponse
+    readonly response?: TransactionResponse
   ) {}
 
   /**
    * Gets the events associated with this transaction.
    */
   getEvents<E extends Event>(eventParser: EventParser<E>): readonly E[] {
+    invariant(this.response, "response not found");
     const logs = this.response.meta?.logMessages;
     if (logs && logs.length > 0) {
       return eventParser(logs);
@@ -36,6 +37,7 @@ export class TransactionReceipt {
    * Prints the logs associated with this transaction.
    */
   printLogs(): void {
+    invariant(this.response, "response not found");
     console.log(this.response.meta?.logMessages?.join("\n"));
   }
 
@@ -44,6 +46,7 @@ export class TransactionReceipt {
    * @returns
    */
   get computeUnits(): number {
+    invariant(this.response, "response not found");
     const logs = this.response.meta?.logMessages;
     invariant(logs, "no logs");
     const consumeLog = logs[logs.length - 2];

--- a/packages/solana-contrib/src/wallet.ts
+++ b/packages/solana-contrib/src/wallet.ts
@@ -41,7 +41,7 @@ export class SignerWallet implements Wallet {
   createProvider(
     connection: Connection,
     sendConnection?: Connection,
-    opts?: ConfirmOptions
+    opts?: ConfirmOptions & { useWaitV2?: boolean }
   ): Provider {
     return SolanaProvider.load({
       connection,


### PR DESCRIPTION
We'll remove `wait` for `waitV2` once we confirm that `waitV2` is stable.
