### PR TITLE
Add isMobile to Phantom provider.

### DIFF
--- a/packages/use-solana/src/providers.tsx
+++ b/packages/use-solana/src/providers.tsx
@@ -96,6 +96,7 @@ export const DEFAULT_WALLET_PROVIDERS: WalletProviderMap<
     makeAdapter: () => new SolanaWalletAdapter(new PhantomWalletAdapter()),
 
     isInstalled: () => window.solana?.isPhantom === true,
+    isMobile: true,
   },
   [DefaultWalletType.MathWallet]: {
     name: "MathWallet",


### PR DESCRIPTION
Would love to have this added for the in-app browser in Phantom mobile. Let me know if there's anything else we need to enable it.

Thanks all!

Example: Step Finance
![telegram-cloud-photo-size-1-5116589510774335901-x](https://user-images.githubusercontent.com/8432766/149190022-6f218c2c-2479-4efd-b716-75c4bd0361c7.jpg)

