### PR TITLE
anchor-contrib: Allow ReadonlyProvider to be used for creating an Anchor provider

### DIFF
--- a/packages/anchor-contrib/src/utils/provider.ts
+++ b/packages/anchor-contrib/src/utils/provider.ts
@@ -1,5 +1,5 @@
 import { Provider as AnchorProvider } from "@project-serum/anchor";
-import type { Provider as SaberProvider } from "@saberhq/solana-contrib";
+import type { ReadonlyProvider as SaberProvider } from "@saberhq/solana-contrib";
 import { SolanaProvider } from "@saberhq/solana-contrib";
 
 /**

--- a/packages/solana-contrib/src/interfaces.ts
+++ b/packages/solana-contrib/src/interfaces.ts
@@ -63,6 +63,16 @@ export interface ReadonlyProvider extends AccountInfoFetcher {
    * Connection for reading data.
    */
   connection: Connection;
+
+  /**
+   * Read-only wallet for use with Anchor programs.
+   */
+  wallet: Wallet;
+
+  /**
+   * Transaction confirmation options to use by default.
+   */
+  opts: ConfirmOptions;
 }
 
 /**


### PR DESCRIPTION
This change allows for read-only Anchor programs to be created using `anchor-contrib`.

The justification for this is when you want to interact with an Anchor program to read account info. This is a very common problem for dashboards such as Step Finance, where we may generally want to read information about a program's accounts without having to connect a wallet.