### PR TITLE
anchor-contrib: Allow ReadonlyProvider in newProgram method

### DIFF
--- a/packages/anchor-contrib/src/utils/programs.ts
+++ b/packages/anchor-contrib/src/utils/programs.ts
@@ -1,6 +1,9 @@
 import type { Idl } from "@project-serum/anchor";
 import { Program } from "@project-serum/anchor";
-import type { Provider as SaberProvider } from "@saberhq/solana-contrib";
+import type {
+  Provider as SaberProvider,
+  ReadonlyProvider as ReadonlySaberProvider,
+} from "@saberhq/solana-contrib";
 import type { PublicKey } from "@solana/web3.js";
 import mapValues from "lodash.mapvalues";
 
@@ -17,7 +20,7 @@ import { makeAnchorProvider } from "./provider";
 export const newProgram = <P>(
   idl: Idl,
   address: PublicKey,
-  provider: SaberProvider
+  provider: SaberProvider | ReadonlySaberProvider
 ) => {
   return new Program(
     idl,
@@ -34,7 +37,7 @@ export const newProgram = <P>(
  * @returns
  */
 export const newProgramMap = <P>(
-  provider: SaberProvider,
+  provider: SaberProvider | ReadonlySaberProvider,
   idls: {
     [K in keyof P]: Idl;
   },

--- a/packages/anchor-contrib/src/utils/provider.ts
+++ b/packages/anchor-contrib/src/utils/provider.ts
@@ -41,7 +41,7 @@ export const makeSaberProvider = (
  * @returns
  */
 export const makeAnchorProvider = (
-  saberProvider: SaberProvider
+  saberProvider: SaberProvider | ReadonlySaberProvider
 ): AnchorProvider => {
   return new AnchorProvider(
     saberProvider.connection,


### PR DESCRIPTION
This PR is a continuation of #461 to allow for use of read-only Anchor providers in `anchor-contrib`'s methods.

- Update `newProgram`/`newProgramMap` to additionally accept a `ReadonlySaberProvider`
- Update `makeAnchorProvider` to accept a `ReadonlySaberProvider`