### PR TITLE
anchor-contrib: Update makeAnchorProvider to accept read-only interface

### DIFF
--- a/packages/anchor-contrib/src/utils/provider.ts
+++ b/packages/anchor-contrib/src/utils/provider.ts
@@ -41,7 +41,7 @@ export const makeSaberProvider = (
  * @returns
  */
 export const makeAnchorProvider = (
-  saberProvider: SaberProvider | ReadonlySaberProvider
+  saberProvider: ReadonlySaberProvider
 ): AnchorProvider => {
   return new AnchorProvider(
     saberProvider.connection,


### PR DESCRIPTION
This PR accompanies #461 & #465 as the final piece of the puzzle. Composing `SaberProvider | ReadonlySaberProvider` in `makeAnchorProvider` requires the passed value to match SaberProvider due to it extending ReadonlySaberProvider. To pass a `SolanaReadonlyProvider` class to `newProgram`, we need to update it to match the `ReadonlySaberProvider` interface for the argument. This will ensure backwards compatibility with the existing `SaberProvider` while allowing read-only providers to be directly passed to `newProgram`.