### PR TITLE
use-solana: Track wallet activation state in useWalletInternal

### DIFF
--- a/packages/use-solana/src/hooks.ts
+++ b/packages/use-solana/src/hooks.ts
@@ -23,8 +23,14 @@ export function useWallet<
  * Gets the current Solana wallet, returning null if it is not connected.
  */
 export const useConnectedWallet = (): ConnectedWallet | null => {
-  const { wallet, connected } = useWallet<UnknownWalletType>();
-  if (!wallet?.connected || !connected || !wallet.publicKey) {
+  const { wallet, connected, walletActivating } =
+    useWallet<UnknownWalletType>();
+  if (
+    !wallet?.connected ||
+    !connected ||
+    !wallet.publicKey ||
+    walletActivating
+  ) {
     return null;
   }
   return wallet as ConnectedWallet;


### PR DESCRIPTION
`useWalletInternal`, which contains the state of connected wallets in `use-solana`, defines a `connected` state which changes on a first-time connect or when a user disconnects their wallet from the application. However, when activating a new wallet, there is a potential race condition where a previously active wallet's public key is cleared and violates the `ConnectedWallet` type when swapping from one wallet type to another. This is a common use case for [Step Finance](https://step.finance) users who switch between multiple different wallets to check positions.

The issue occurs when the `activate` function is called from the `useWalletInternal` hook. Because the wallet's `connected` state never transitions to disconnected (an existing connected wallet transitioning to a different wallet provider), it is possible for `publicKey` to never emit a state change from the hook and remain `undefined`.

In order to support this, I have made the following changes:
- Add `walletActivating` state to `useWalletInternal` to track when activation completes
- Update `useConnectedWallet` to await wallet activation before `ConnectedWallet` becomes defined