### PR TITLE
solana-contrib: Avoid using getter for an interface

### DIFF
--- a/packages/solana-contrib/src/provider.ts
+++ b/packages/solana-contrib/src/provider.ts
@@ -326,9 +326,9 @@ export class SolanaProvider extends SolanaReadonlyProvider implements Provider {
  */
 export interface AugmentedProvider extends Provider {
   /**
-   * Gets the {@link PublicKey} of the wallet.
+   * The {@link PublicKey} of the wallet.
    */
-  get walletKey(): PublicKey;
+  readonly walletKey: PublicKey;
 
   /**
    * Creates a new transaction using this Provider.


### PR DESCRIPTION
TypeScript does not allow interfaces to use getters and/or setters (https://github.com/microsoft/TypeScript/issues/3745).
However, `AugmentedProvider` interface in `solana-contrib` uses getter for `walletKey` and causes type issues.

In this PR, the getter is alternated by a property and it fixes the issue.
