### PR TITLE
Handle async errors when using fallback connections to send raw tx.

### DIFF
--- a/packages/solana-contrib/src/broadcaster/tiered.ts
+++ b/packages/solana-contrib/src/broadcaster/tiered.ts
@@ -70,12 +70,16 @@ export class TieredBroadcaster implements Broadcaster {
     void (async () => {
       await Promise.all(
         this.fallbackConnections.map(async (fc) => {
-          await sendAndSpamRawTx(
-            fc,
-            encoded,
-            options ?? this.opts,
-            options?.fallbackRetryOptions ?? DEFAULT_FALLBACK_RETRY_OPTIONS
-          );
+          try {
+            await sendAndSpamRawTx(
+              fc,
+              encoded,
+              options ?? this.opts,
+              options?.fallbackRetryOptions ?? DEFAULT_FALLBACK_RETRY_OPTIONS
+            );
+          } catch (e) {
+            console.warn(`[Broadcaster] _sendRawTransaction error`, e);
+          }
         })
       );
     })();


### PR DESCRIPTION
Otherwise the async loop can cause the entire process to crash if eg `sendAndSpamRawTx` throws an error [here](https://github.com/saber-hq/saber-common/blob/e5f2a37a7daf123d1c4accdabe72072f63ec0386/packages/solana-contrib/src/broadcaster/sendAndSpamRawTx.ts#L22).