### PR TITLE
Replace project serum rpc with solana

### DIFF
--- a/packages/solana-contrib/src/constants.ts
+++ b/packages/solana-contrib/src/constants.ts
@@ -37,7 +37,7 @@ export type NetworkConfig = Readonly<
 export const DEFAULT_NETWORK_CONFIG_MAP = {
   "mainnet-beta": {
     name: "Mainnet Beta",
-    endpoint: "https://solana-api.projectserum.com/",
+    endpoint: "https://api.mainnet-beta.solana.com/",
   },
   devnet: {
     name: "Devnet",


### PR DESCRIPTION
It seems like the project serum api has gone down amid the FTX events. This PR changes it to the one provided with solana which is less likely to have issues given that the status of project serum is now uncertain. 